### PR TITLE
Add e2e api test build

### DIFF
--- a/slack-e2e-api-tests/build/Jenkinsfile
+++ b/slack-e2e-api-tests/build/Jenkinsfile
@@ -1,0 +1,36 @@
+pipeline {
+  agent any
+
+  stage('Clone repository') {
+    checkout([
+      $class: 'GitSCM',
+      branches: [[name: '*/master']],
+      doGenerateSubmoduleConfigurations: false,
+      extensions: [],
+      submoduleCfg: [],
+      userRemoteConfigs: [[
+        credentialsId: '088d3940-55c4-4d8c-85c5-007886b9555c',
+        url: 'git@github.com:ClearPointNZ/connect-sample-apps.git'
+      ]]
+    ])
+  }
+
+  stage('Build e2e api tests') {
+    sh '''
+      cd slack-e2e-api-tests;
+      mvn clean install;
+    '''
+  }
+
+  stage('Build image') {
+    sh '''
+      echo 'build image if not already buit by Maven plugin'
+    '''
+  }
+
+  stage('Test image') {
+    app.withRun {
+      echo 'This is a test!'
+    }
+  }
+}

--- a/slack-e2e-api-tests/build/Jenkinsfile
+++ b/slack-e2e-api-tests/build/Jenkinsfile
@@ -15,10 +15,16 @@ pipeline {
     ])
   }
 
+  stage('Configure env yaml file') {
+    sh '''
+      cd slack-e2e-api-tests;
+      cp src/test/resources/env.yml.example src/test/resources/env.yml;
+    '''
+
   stage('Build e2e api tests') {
     sh '''
       cd slack-e2e-api-tests;
-      mvn clean install;
+      mvn clean install -DskipTests;
     '''
   }
 

--- a/slack-e2e-api-tests/build/pipline_job.groovy
+++ b/slack-e2e-api-tests/build/pipline_job.groovy
@@ -1,0 +1,16 @@
+pipelineJob('slack-sentiment-e2e-api-build') {
+  description('Build end to end tests')
+  triggers {
+    scm('*/5 * * * *')
+  }
+  definition {
+    cpsScm {
+      scm {
+        git('git@github.com:ClearPointNZ/connect-sample-apps.git') {
+          node -> node / extensions()
+        }
+      }
+      scriptPath('slack-e2e-api-tests/build/Jenkinsfile')
+    }
+  }
+}


### PR DESCRIPTION
So, the idea is that the "meta" job in Jenkins should automatically pick up the Groovy file here and create the pipeline as per the Jenkins file.

Therefore, when creating a "new" service, in order to setup a new build you would:

* Create a directory with the name of your new service
* In that directory have a "build" directory
* In the "build" directory have a .groovy file and a Jenkinsfile file to define your build