### PR TITLE
Change DOCKER_HOST to be Groovy variable

### DIFF
--- a/slack-message-reader/build/Jenkinsfile
+++ b/slack-message-reader/build/Jenkinsfile
@@ -1,8 +1,6 @@
 node("k8s-dind-worker") {
 
-  environment {
-      DOCKER_HOST = 'tcp://localhost:2375'
-  }
+  DOCKER_HOST = 'tcp://localhost:2375'
 
   stage('Clone repository') {
     checkout([


### PR DESCRIPTION
Changing the variable to be an Groovy variable instead of an Environment
variable.

This appears to have been breaking the builds.

Issue(s): None