### PR TITLE
Make Jenkinsfile use declarative pipeline

### DIFF
--- a/slack-e2e-api-tests/build/Jenkinsfile
+++ b/slack-e2e-api-tests/build/Jenkinsfile
@@ -1,4 +1,6 @@
-node("k8s-dind-worker") {
+pipeline {
+
+  agent { label 'k8s-dind-worker' }
 
   environment {
       DOCKER_HOST = 'tcp://localhost:2375'
@@ -33,7 +35,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'

--- a/slack-message-reader-api/build/Jenkinsfile
+++ b/slack-message-reader-api/build/Jenkinsfile
@@ -1,4 +1,6 @@
-node("k8s-dind-worker") {
+pipeline {
+
+  agent { label 'k8s-dind-worker' }
 
   environment {
       DOCKER_HOST = 'tcp://localhost:2375'
@@ -25,7 +27,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'

--- a/slack-message-reader/build/Jenkinsfile
+++ b/slack-message-reader/build/Jenkinsfile
@@ -1,6 +1,10 @@
-node("k8s-dind-worker") {
+pipeline {
 
-  DOCKER_HOST = 'tcp://localhost:2375'
+  agent { label 'k8s-dind-worker' }
+
+  environment {
+    DOCKER_HOST = 'tcp://localhost:2375'
+  }
 
   stage('Clone repository') {
     checkout([
@@ -23,7 +27,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'

--- a/slack-sentiment-analyser-api/build/Jenkinsfile
+++ b/slack-sentiment-analyser-api/build/Jenkinsfile
@@ -1,4 +1,4 @@
-node("k8s-dind-worker") {
+pipeline {
 
   environment {
       DOCKER_HOST = 'tcp://localhost:2375'
@@ -25,7 +25,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'

--- a/slack-sentiment-analyser/build/Jenkinsfile
+++ b/slack-sentiment-analyser/build/Jenkinsfile
@@ -1,4 +1,6 @@
-node("k8s-dind-worker") {
+pipeline {
+
+  agent { label 'k8s-dind-worker' }
 
   environment {
       DOCKER_HOST = 'tcp://localhost:2375'
@@ -25,7 +27,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'

--- a/slack-sentiment-parser-api/build/Jenkinsfile
+++ b/slack-sentiment-parser-api/build/Jenkinsfile
@@ -1,4 +1,4 @@
-node("k8s-dind-worker") {
+pipeline {
 
   environment {
       DOCKER_HOST = 'tcp://localhost:2375'
@@ -25,7 +25,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'

--- a/slack-sentiment-parser/build/Jenkinsfile
+++ b/slack-sentiment-parser/build/Jenkinsfile
@@ -1,4 +1,4 @@
-node("k8s-dind-worker") {
+pipeline {
 
   environment {
       DOCKER_HOST = 'tcp://localhost:2375'
@@ -25,7 +25,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'

--- a/slack-vibe/build/Jenkinsfile
+++ b/slack-vibe/build/Jenkinsfile
@@ -1,4 +1,4 @@
-node("k8s-dind-worker") {
+pipeline {
 
   environment {
       DOCKER_HOST = 'tcp://localhost:2375'
@@ -25,7 +25,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'

--- a/slacklistener/build/Jenkinsfile
+++ b/slacklistener/build/Jenkinsfile
@@ -1,4 +1,4 @@
-node("k8s-dind-worker") {
+pipeline {
 
   environment {
       DOCKER_HOST = 'tcp://localhost:2375'
@@ -25,7 +25,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'

--- a/utils/build/Jenkinsfile
+++ b/utils/build/Jenkinsfile
@@ -1,4 +1,4 @@
-node("k8s-dind-worker") {
+pipeline {
 
   environment {
       DOCKER_HOST = 'tcp://localhost:2375'
@@ -25,7 +25,7 @@ node("k8s-dind-worker") {
         usernameVariable: 'NEXUS_USR',
         passwordVariable: 'NEXUS_PSW'
     ]]) {
-        docker.withServer(DOCKER_HOST) {
+        docker.withServer(env.DOCKER_HOST) {
             docker.image('ikhripunov/connect-maven:latest').withRun('-v "$PWD":/usr/src/mymaven -w /usr/src/mymaven') {
                 docker.image('ikhripunov/connect-maven:latest').inside() {
                     sh 'cp /usr/share/maven/ref/settings.xml ~/.m2/settings.xml'


### PR DESCRIPTION
Ensure that we use declarative syntax for defining the pipelines. This
means we have to switch DOCKER_HOST to be an environment variable rather
than a Groovy one as declarative syntax doesn't allow decleration of
Groovy variables in the Jenkinsfile.

Issue(s): None